### PR TITLE
改為即時更新, 在頁面有變動的時候就更新

### DIFF
--- a/myscript.js
+++ b/myscript.js
@@ -1,18 +1,39 @@
-var interval = 5000;
 var isEnabled = true;
-var timer = null;
+
+function change(node){
+  var key;
+  var p = node;
+  while( p && p!=document.body ){
+    if( p.isContentEditable )
+      return;
+    p = p.parentNode;
+  }
+  if( node.nodeName === '#text' ){
+    for(key in dict)
+      node.data = node.data.replace(new RegExp(key, 'g'), dict[key]);
+  }
+  else{
+    for(key in dict){
+      findAndReplaceDOMText(node, {
+        find: new RegExp(key, "g"),
+        replace: dict[key]
+      });
+    }
+  }
+}
 
 // https://github.com/padolsey/findAndReplaceDOMText
-function change(){
-	for(var key in dict){
-		findAndReplaceDOMText(document, {
-		  find: new RegExp(key, "g"),
-		  replace: dict[key]
-		});	
-	}
-	//console.log('run..');
-	setTimeout(change, interval);
+function each(arr, act){
+  var i;
+  for(i=0; i<arr.length; ++i)
+    act(arr[i]);
 }
+
+var observer = new MutationObserver(function(mutations){
+  each(mutations, function(mutation){
+    each(mutation.addedNodes, change);
+  });
+});
 
 // 跟 background 互通
 function setListener(){
@@ -28,15 +49,18 @@ function setListener(){
 	    	// 剛開始是關閉的，現在要啟動
 	    	if(window.firstEnabled===false && isEnabled){
 	    		window.firstEnabled = true
-	    		change();
+	    		change(document.body);
+                        observer.observe(document.body, {childList:true, subtree:true});
 	    	}
 	    	return;
 	    }
 
 	    if(isEnabled){
-	    	change();
+	    	change(document.body);
+                observer.observe(document.body, {childList:true, subtree:true});
 	    }else{
 	    	window.firstEnabled = false;
+                observer.disconnect();
 	    }
   });
 }


### PR DESCRIPTION
我作這一個修改, 把每5秒更新一次的作法改成偵測頁面的變動, 在發現變動的時候即時更新這樣~
這樣比較不會看到還沒換到的字, 在頁面不動的時候也比較省效能...

另外就是我有對 user 編輯中的文字作處理, 避免改動正在打的字, 因為它會影響到我用的輪入法在 FB 輸入時的組字過程... ^^|
